### PR TITLE
live.tab only output on pointer move when value is changing

### DIFF
--- a/src/js/objects/live.tab.js
+++ b/src/js/objects/live.tab.js
@@ -225,8 +225,9 @@ export default class LiveTab extends MiraUIObject {
 	}
 
 	pointerMove(event, params) {
-		let tab = event.attributes.tab;
-		if (tab !== undefined) this.setParamValue("value", tab);
+		const tab = event.attributes.tab;
+		const { value } = params;
+		if (tab !== undefined && value !== tab) this.setParamValue("value", tab);
 	}
 
 	pointerUp(event, params) {


### PR DESCRIPTION
Simple fix for #117 in order to prevent changing the value when the pointer move isn't reaching a different value tab