### PR TITLE
Fix mira.multitouch to report rotation value correctly

### DIFF
--- a/src/js/lib/gestureEvent.js
+++ b/src/js/lib/gestureEvent.js
@@ -1,3 +1,5 @@
+import { toRad } from "./utils";
+
 class GestureEvent {
 
 	constructor(options) {
@@ -69,7 +71,8 @@ class RotateGesture extends GestureEvent {
 		super(options);
 
 		this._ongoing = options.isFinal ? 0 : 1;
-		this._rotate = options.rotate;
+		this._rotation = options.rotation;
+		this._rotationRad = toRad(this._rotation);
 		this._velocity = options.velocity;
 	}
 
@@ -77,8 +80,12 @@ class RotateGesture extends GestureEvent {
 		return this._ongoing;
 	}
 
-	get rotate() {
-		return this._rotate;
+	get rotation() {
+		return this._rotation;
+	}
+
+	get rotationRad() {
+		return this._rotationRad;
 	}
 
 	get velocity() {

--- a/src/js/lib/pixiUiObject.js
+++ b/src/js/lib/pixiUiObject.js
@@ -635,7 +635,7 @@ class PixiDraw extends EventEmitter {
 			"offsetDirection",
 
 			"scale",
-			"rotate",
+			"rotation",
 
 			"isFirst",
 			"isFinal"

--- a/src/js/objects/mira.multitouch.js
+++ b/src/js/objects/mira.multitouch.js
@@ -379,7 +379,7 @@ export default class MiraMultitouch extends MiraUIObject {
 			0, // Sequence number, always 0
 			XebraStateStore.getXebraUuid(),
 			XebraStateStore.getXebraUuid(),
-			event.rotate,
+			event.rotationRad,
 			event.velocity,
 			event.ongoing
 		]);


### PR DESCRIPTION
This is a fix for #116 Basically there were some typos and missing conversion to radians in order to allow mira.multitouch to report the touch rotation value correctly. This should mostly work but I think it needs some offset adjustment in order to map the rotation value correctly, as done by Mira App. I don't have access to a Mira App install right now so I might need your help @starakaj to figure out how the rotation is supposed to be reported so we apply the correct offset here before we merge this PR into dev.